### PR TITLE
Refiner panicking on Data Lake mode run

### DIFF
--- a/contrib/Dockerfile.refiner
+++ b/contrib/Dockerfile.refiner
@@ -20,6 +20,9 @@ FROM ubuntu:latest
 
 COPY --from=build /refiner/borealis-engine-lib/target/release/aurora-refiner /usr/local/bin/
 
+RUN apt update
+RUN apt install ca-certificates -y
+
 RUN mkdir /config /data
 VOLUME /config
 VOLUME /data


### PR DESCRIPTION
Due to the missing certificate package, running Data Lake mode results in an error:
```
2022-12-22T05:43:46.114712Z  INFO aurora_refiner_lib::storage: No engine_account_id set in DB. Setting to configured engine_account_id=aurora
thread 'main' panicked at 'no CA certificates found', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-rustls-0.22.1/src/connector.rs:45:13
```

After changes in this PR Data Lake mode works as expected.