### PR TITLE
Fix nearlake testnet refiner configuration

### DIFF
--- a/contrib/config/refiner/testnet_datalake.json
+++ b/contrib/config/refiner/testnet_datalake.json
@@ -7,7 +7,7 @@
     },
     "input_mode": {
         "DataLake": {
-            "network": "Mainnet"
+            "network": "Testnet"
         }
     },
     "output_storage": {


### PR DESCRIPTION
Current configuration uses mainnet for testnet, this PR fixes it.