### PR TITLE
Update signer key generation

### DIFF
--- a/contrib/config/build/nearkey.go
+++ b/contrib/config/build/nearkey.go
@@ -62,6 +62,9 @@ func newKey(accountid string) string {
 	if err != nil {
 		panic(err) // This should never occur.
 	}
+	if accountid == "" {
+		accountid = hex.EncodeToString(pub)
+	}
 	kf := &KeyFile{
 		AccountID: accountid,
 		PublicKey: prefix + encode58(pub),

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,10 @@ fi
 
 install() {
 
+  if [ "${network}" = "testnet" ]; then
+	  near_postfix="testnet"
+  fi
+
   if [ -f "${VERSION_FILE}" ]; then
     echo "There is already an Aurora Standalone RPC installation running or an unfinished installation exists"
     if confirmed "To continue with installation, you have to first uninstall. Would you like to uninstall?"; then
@@ -44,7 +48,7 @@ install() {
 
   if [ ! -f "${INSTALL_DIR}/config/relayer/relayer.json" ]; then
     echo "Generating relayer key..."
-    docker run --rm --name near_keygen -v "$(pwd)/${INSTALL_DIR}"/config/relayer:/config:rw --entrypoint /bin/sh nearaurora/srpc2-relayer -c "/usr/local/bin/nearkey relayer%.${near_postfix} > /config/relayer.json"
+    docker run --rm --name near_keygen -v "$(pwd)/${INSTALL_DIR}"/config/relayer:/config:rw --entrypoint /bin/sh nearaurora/srpc2-relayer -c "/usr/local/bin/nearkey > /config/relayer.json"
     relayerName=$(cat "${INSTALL_DIR}/config/relayer/relayer.json" | grep account_id | cut -d\" -f4)
     sed "s/%%SIGNER%%/${relayerName}/" "${INSTALL_DIR}/config/relayer/relayer.yaml" > "${INSTALL_DIR}/config/relayer/relayer.yaml2" && \
     mv "${INSTALL_DIR}/config/relayer/relayer.yaml2" "${INSTALL_DIR}/config/relayer/relayer.yaml"


### PR DESCRIPTION
Premise:
We use nearkey to generate 3 types of key pairs.
`Account Id` in `node_key.json` and `validator_key.json` used only for descriptive purposes, so I suggest we follow near practice by adding near or testnet depending on network, as we once did [here](https://github.com/aurora-is-near/partner-relayer-deploy/blob/main/setup.sh#L6-L8)

While for `relayer.json` I suggest to actually provide implicit address, so users can actually top it up, thus enabling relayer to submit transactions.

