### PR TITLE
chore: update default gas price as 0.07 Gwei

### DIFF
--- a/contrib/config/relayer/mainnet.yaml
+++ b/contrib/config/relayer/mainnet.yaml
@@ -35,7 +35,9 @@ endpoint:
     protocolVersion: 0x41
     hashrate: 0
     gasEstimate: 0x6691b7
-    gasPrice: 0x0
+    # 0.07 Gwei, see
+    # https://doc.aurora.dev/blog/create-virtual-chain/#setting-the-gas-price
+    gasPrice: 0x42c1d80
   proxyEndpoints:
     url: "https://mainnet.aurora.dev:443"
     endpoints:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ethereum gas price configuration for the mainnet relayer.
* **Documentation**
  * Added inline comments documenting the gas price setting with reference information for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->